### PR TITLE
fix: update controls hook for Foundry v13

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,10 +2,10 @@
   "id": "tsl-strings-tracker",
   "title": "Thirsty Sword Lesbians - Strings Tracker",
   "description": "A visual strings tracking system for Thirsty Sword Lesbians using official VTT assets",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "compatibility": {
     "minimum": "10",
-    "verified": "12",
+    "verified": "13",
     "maximum": "13"
   },
   "authors": [

--- a/scripts/tsl-strings.js
+++ b/scripts/tsl-strings.js
@@ -258,8 +258,12 @@ Hooks.on('getSceneControlButtons', (controls) => {
     return;
   }
 
+  // Foundry VTT v13 passes a SceneControls instance instead of an array
+  // of controls. Support both formats for backward compatibility.
+  const controlsArray = Array.isArray(controls) ? controls : controls.controls;
+
   // Find the token controls
-  const tokenControls = controls.find(c => c.name === 'token');
+  const tokenControls = controlsArray?.find(c => c.name === 'token');
   if (!tokenControls) return;
 
   // Check if our tool already exists (prevent duplicates)


### PR DESCRIPTION
## Summary
- support Foundry v13 `getSceneControlButtons` API change
- update module metadata for v13

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68920130bca083248fb8102d00ffe908